### PR TITLE
Fix CodeQL code scanning alerts

### DIFF
--- a/examples/test_compare_models.py
+++ b/examples/test_compare_models.py
@@ -56,6 +56,9 @@ def llm(request):
         return _get_azure_llm()
     elif request.param == "vertex":
         return _get_vertex_llm()
+    else:
+        msg = f"Unknown provider: {request.param}"
+        raise ValueError(msg)
 
 
 class TestModelComparison:

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -10,12 +10,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
-
 import pytest
-
-if TYPE_CHECKING:
-    from pytest_llm_assert import LLMAssert
 
 
 # Load .env from workspace root (search upward)
@@ -106,6 +101,9 @@ def llm(request, azure_llm_factory, vertex_llm_factory):
         return azure_llm_factory(AZURE_DEPLOYMENT)
     elif request.param == "vertex":
         return vertex_llm_factory(VERTEX_MODEL)
+    else:
+        msg = f"Unknown provider: {request.param}"
+        raise ValueError(msg)
 
 
 class TestBasicAssertions:

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -77,16 +77,15 @@ class TestPackageExports:
 
     def test_version_available(self) -> None:
         """Package version should be accessible."""
-        import pytest_llm_assert
+        from pytest_llm_assert import __version__
 
-        assert hasattr(pytest_llm_assert, "__version__")
-        assert pytest_llm_assert.__version__ == "0.1.0"
+        assert __version__ == "0.1.0"
 
     def test_all_exports(self) -> None:
         """__all__ should list expected exports."""
-        import pytest_llm_assert
+        from pytest_llm_assert import __all__ as exports
 
-        assert set(pytest_llm_assert.__all__) == {
+        assert set(exports) == {
             "LLMAssert",
             "AssertionResult",
             "LLMResponse",


### PR DESCRIPTION
## Summary
Resolves all 5 open CodeQL code scanning alerts.

## Changes
- **tests/integration/test_llm_integration.py**: Remove unused TYPE_CHECKING import, add explicit else clause
- **examples/test_compare_models.py**: Add explicit else clause for unhandled fixture param
- **tests/unit/test_plugin.py**: Use only \rom\ imports instead of mixing \import\ and \rom\

## Testing
All 65 unit tests pass.

Fixes #14