### PR TITLE
fix: resolve mkdocs strict mode warnings

### DIFF
--- a/docs/comparing-models.md
+++ b/docs/comparing-models.md
@@ -4,7 +4,7 @@ Not sure which LLM to use as your assertion judge? Different models have differe
 
 ## Example
 
-See [`examples/test_compare_models.py`](../examples/test_compare_models.py) for a working example that compares Azure OpenAI and Vertex AI.
+See [`examples/test_compare_models.py`](https://github.com/sbroenne/pytest-llm-assert/blob/main/examples/test_compare_models.py) for a working example that compares Azure OpenAI and Vertex AI.
 
 Run it with:
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ def llm():
 
 ## Custom System Prompt
 
-The default system prompt is in [`src/pytest_llm_assert/prompts/system_prompt.md`](../src/pytest_llm_assert/prompts/system_prompt.md).
+The default system prompt is in [`src/pytest_llm_assert/prompts/system_prompt.md`](https://github.com/sbroenne/pytest-llm-assert/blob/main/src/pytest_llm_assert/prompts/system_prompt.md).
 
 Override it at runtime for domain-specific assertions:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,11 @@ nav:
   - Configuration: configuration.md
   - API Reference: api-reference.md
   - Comparing Models: comparing-models.md
+  - Integration Tests: INTEGRATION_TESTS.md
+  - GitHub Setup Guide: GITHUB_SETUP_GUIDE.md
+
+exclude_docs: |
+  README.md
 
 extra:
   social:


### PR DESCRIPTION
Fixes the docs build failure from the v0.2.4 release workflow.

- Fix broken link in `comparing-models.md` → use GitHub URL for the example file
- Fix broken link in `configuration.md` → use GitHub URL for `system_prompt.md`
- Add `INTEGRATION_TESTS.md` and `GITHUB_SETUP_GUIDE.md` to the nav
- Exclude `README.md` from docs to avoid conflict with `index.md`